### PR TITLE
Feburary work

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,5 +26,6 @@ jobs:
           name: clover_sim
           path: |
             virgl
+            sim
             clover_sim
   

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "files.watcherExclude": {
+    "base_fs/**": true,
+    "containers/**": true,
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,6 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d // indirect
 	github.com/russross/blackfriday/v2 v2.0.1 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,10 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5I
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/sim/build.sh
+++ b/sim/build.sh
@@ -7,3 +7,4 @@ source /etc/profile
 source ~/.bashrc
 cd /home/clover/catkin_ws/
 catkin_make cloversim
+history -c

--- a/sim/build.sh
+++ b/sim/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# This script will copy and build cloversim simulator files
+cp -r /sim/cloversim /home/clover/catkin_ws/src/cloversim
+chown clover /home/clover/catkin_ws/src/cloversim
+
+source /etc/profile
+source ~/.bashrc
+cd /home/clover/catkin_ws/
+catkin_make cloversim

--- a/sim/cloversim/CMakeLists.txt
+++ b/sim/cloversim/CMakeLists.txt
@@ -1,0 +1,206 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(cloversim)
+
+## Compile as C++11, supported in ROS Kinetic and newer
+# add_compile_options(-std=c++11)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS
+  rospy
+)
+
+## System dependencies are found with CMake's conventions
+# find_package(Boost REQUIRED COMPONENTS system)
+
+
+## Uncomment this if the package has a setup.py. This macro ensures
+## modules and global scripts declared therein get installed
+## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+# catkin_python_setup()
+
+################################################
+## Declare ROS messages, services and actions ##
+################################################
+
+## To declare and build messages, services or actions from within this
+## package, follow these steps:
+## * Let MSG_DEP_SET be the set of packages whose message types you use in
+##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
+## * In the file package.xml:
+##   * add a build_depend tag for "message_generation"
+##   * add a build_depend and a exec_depend tag for each package in MSG_DEP_SET
+##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
+##     but can be declared for certainty nonetheless:
+##     * add a exec_depend tag for "message_runtime"
+## * In this file (CMakeLists.txt):
+##   * add "message_generation" and every package in MSG_DEP_SET to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * add "message_runtime" and every package in MSG_DEP_SET to
+##     catkin_package(CATKIN_DEPENDS ...)
+##   * uncomment the add_*_files sections below as needed
+##     and list every .msg/.srv/.action file to be processed
+##   * uncomment the generate_messages entry below
+##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#   Service1.srv
+#   Service2.srv
+# )
+
+## Generate actions in the 'action' folder
+# add_action_files(
+#   FILES
+#   Action1.action
+#   Action2.action
+# )
+
+## Generate added messages and services with any dependencies listed here
+# generate_messages(
+#   DEPENDENCIES
+#   std_msgs  # Or other packages containing msgs
+# )
+
+################################################
+## Declare ROS dynamic reconfigure parameters ##
+################################################
+
+## To declare and build dynamic reconfigure parameters within this
+## package, follow these steps:
+## * In the file package.xml:
+##   * add a build_depend and a exec_depend tag for "dynamic_reconfigure"
+## * In this file (CMakeLists.txt):
+##   * add "dynamic_reconfigure" to
+##     find_package(catkin REQUIRED COMPONENTS ...)
+##   * uncomment the "generate_dynamic_reconfigure_options" section below
+##     and list every .cfg file to be processed
+
+## Generate dynamic reconfigure parameters in the 'cfg' folder
+# generate_dynamic_reconfigure_options(
+#   cfg/DynReconf1.cfg
+#   cfg/DynReconf2.cfg
+# )
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if your package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES cloversim
+#  CATKIN_DEPENDS rospy
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+include_directories(
+# include
+  ${catkin_INCLUDE_DIRS}
+)
+
+## Declare a C++ library
+# add_library(${PROJECT_NAME}
+#   src/${PROJECT_NAME}/cloversim.cpp
+# )
+
+## Add cmake target dependencies of the library
+## as an example, code may need to be generated before libraries
+## either from message generation or dynamic reconfigure
+# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Declare a C++ executable
+## With catkin_make all packages are built within a single CMake context
+## The recommended prefix ensures that target names across packages don't collide
+# add_executable(${PROJECT_NAME}_node src/cloversim_node.cpp)
+
+## Rename C++ executable without prefix
+## The above recommended prefix causes long target names, the following renames the
+## target back to the shorter version for ease of user use
+## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
+# set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
+
+## Add cmake target dependencies of the executable
+## same as for the library above
+# add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+
+## Specify libraries to link a library or executable target against
+# target_link_libraries(${PROJECT_NAME}_node
+#   ${catkin_LIBRARIES}
+# )
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+catkin_install_python(PROGRAMS
+  scripts/sim_proxy
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+## Mark executables for installation
+## See http://docs.ros.org/melodic/api/catkin/html/howto/format1/building_executables.html
+# install(TARGETS ${PROJECT_NAME}_node
+#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark libraries for installation
+## See http://docs.ros.org/melodic/api/catkin/html/howto/format1/building_libraries.html
+# install(TARGETS ${PROJECT_NAME}
+#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+# )
+
+## Mark cpp header files for installation
+# install(DIRECTORY include/${PROJECT_NAME}/
+#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+#   FILES_MATCHING PATTERN "*.h"
+#   PATTERN ".svn" EXCLUDE
+# )
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+# install(FILES
+#   # myfile1
+#   # myfile2
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
+
+install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_cloversim.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/sim/cloversim/launch/copter.launch
+++ b/sim/cloversim/launch/copter.launch
@@ -1,0 +1,34 @@
+<launch>
+    <arg name="type" default="gazebo"/> <!-- gazebo, jmavsim, none (only clover packages) -->
+    <arg name="mav_id" default="0"/>
+    <arg name="est" default="ekf2"/> <!-- PX4 estimator: lpe, ekf2 -->
+    <arg name="vehicle" default="clover"/> <!-- PX4 vehicle configuration: clover, clover_vpe -->
+    <arg name="main_camera" default="true"/> <!-- Simulated vision position estimation camera (optical flow, ArUco) -->
+    <arg name="maintain_camera_rate" default="false"/> <!-- Slow simulation down to maintain camera rate -->
+    <arg name="rangefinder" default="true"/> <!-- Simulated downward-facing rangefinder, vl53l1x-like -->
+    <arg name="led" default="true"/> <!-- Simulated LED strip, ws281x-like -->
+    <arg name="gps" default="false"/> <!--Simulated GPS module -->
+    <arg name="use_clover_physics" default="false"/> <!-- Use inertial parameters from CAD models -->
+    <arg name="gui" default="true"/> <!-- Run Gazebo with GUI -->
+
+
+    <!-- PX4 instance -->
+    <node name="sitl_$(arg mav_id)" pkg="px4" type="px4" output="screen" args="$(find px4)/ROMFS/px4fmu_common -s etc/init.d-posix/rcS -i $(arg mav_id)" unless="$(eval type == 'none')">
+        <env name="PX4_SIM_MODEL" value="$(arg vehicle)"/>
+        <env name="PX4_ESTIMATOR" value="$(arg est)"/>
+        <env name="PX4_SIM_HOST_ADDR" value="192.168.77.2" />
+    </node>
+
+    <!-- Clover services -->
+    <include file="$(find clover)/launch/clover.launch">
+        <arg name="simulator" value="true"/>
+        <arg name="fcu_conn" value="sitl"/>
+        <arg name="fcu_ip" value="127.0.0.1"/>
+        <arg name="gcs_bridge" value="udp-b"/>
+        <arg name="web_video_server" default="false" if="$(eval type == 'jmavsim')"/>
+        <arg name="main_camera" default="false" if="$(eval type == 'jmavsim')"/>
+        <arg name="aruco" default="false" if="$(eval type == 'jmavsim')"/>
+        <arg name="optical_flow" default="false" if="$(eval type == 'jmavsim')"/>
+        <arg name="led" default="false" if="$(eval type == 'jmavsim')"/>
+    </include>
+</launch>

--- a/sim/cloversim/launch/simulator.launch
+++ b/sim/cloversim/launch/simulator.launch
@@ -1,0 +1,36 @@
+<launch>
+    <arg name="type" default="gazebo"/> <!-- gazebo, jmavsim, none (only clover packages) -->
+    <arg name="mav_id" default="0"/>
+    <arg name="est" default="ekf2"/> <!-- PX4 estimator: lpe, ekf2 -->
+    <arg name="vehicle" default="clover"/> <!-- PX4 vehicle configuration: clover, clover_vpe -->
+    <arg name="main_camera" default="true"/> <!-- Simulated vision position estimation camera (optical flow, ArUco) -->
+    <arg name="maintain_camera_rate" default="false"/> <!-- Slow simulation down to maintain camera rate -->
+    <arg name="rangefinder" default="true"/> <!-- Simulated downward-facing rangefinder, vl53l1x-like -->
+    <arg name="led" default="true"/> <!-- Simulated LED strip, ws281x-like -->
+    <arg name="gps" default="false"/> <!--Simulated GPS module -->
+    <arg name="use_clover_physics" default="false"/> <!-- Use inertial parameters from CAD models -->
+    <arg name="gui" default="true"/> <!-- Run Gazebo with GUI -->
+
+    <!-- Gazebo instance -->
+    <include file="$(find gazebo_ros)/launch/empty_world.launch" if="$(eval type == 'gazebo')">
+        <!-- Workaround for crashes in VMware -->
+        <env name="SVGA_VGPU10" value="0"/>
+        <arg name="gui" value="$(arg gui)"/>
+        <arg name="world_name" value="$(find clover_simulation)/resources/worlds/clover_aruco.world"/>
+        <arg name="verbose" value="true"/>
+    </include>
+
+    <!-- Clover model -->
+    <include file="$(find clover_description)/launch/spawn_drone.launch" if="$(eval type == 'gazebo')">
+        <arg name="main_camera" value="$(arg main_camera)"/>
+        <arg name="maintain_camera_rate" value="$(arg maintain_camera_rate)"/>
+        <arg name="rangefinder" value="$(arg rangefinder)"/>
+        <arg name="led" value="$(arg led)"/>
+        <arg name="gps" value="$(arg gps)"/>
+        <arg name="use_clover_physics" value="$(arg use_clover_physics)"/>
+    </include>
+
+    <node name="sim_proxy" pkg="cloversim" type="sim_proxy" >
+        <env name="PROXY_ADDRESS" value="http://clover0:11311"/>
+    </node>
+</launch>

--- a/sim/cloversim/package.xml
+++ b/sim/cloversim/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>cloversim</name>
-  <version>0.0.0</version>
+  <version>0.0.1</version>
   <description>The cloversim package</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag -->

--- a/sim/cloversim/package.xml
+++ b/sim/cloversim/package.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>cloversim</name>
+  <version>0.0.0</version>
+  <description>The cloversim package</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="clover@todo.todo">clover</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>TODO</license>
+
+
+  <!-- Url tags are optional, but multiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://wiki.ros.org/cloversim</url> -->
+
+
+  <!-- Author tags are optional, multiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintainers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
+  <!--   <depend>roscpp</depend> -->
+  <!--   Note that this is equivalent to the following: -->
+  <!--   <build_depend>roscpp</build_depend> -->
+  <!--   <exec_depend>roscpp</exec_depend> -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use build_export_depend for packages you need in order to build against this package: -->
+  <!--   <build_export_depend>message_generation</build_export_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use exec_depend for packages you need at runtime: -->
+  <!--   <exec_depend>message_runtime</exec_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <!-- Use doc_depend for packages you need only for building documentation: -->
+  <!--   <doc_depend>doxygen</doc_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>rospy</build_depend>
+  <build_export_depend>rospy</build_export_depend>
+  <exec_depend>rospy</exec_depend>
+
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/sim/cloversim/scripts/sim_proxy
+++ b/sim/cloversim/scripts/sim_proxy
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+
+import os
+import selectors
+import socket
+from xmlrpc.client import ServerProxy
+from xmlrpc.server import SimpleXMLRPCServer, SimpleXMLRPCRequestHandler
+from urllib.parse import urlparse
+
+CALLER_ID = "/sim_proxy"
+
+topics_map = {
+  "/main_camera/image_raw": "sensor_msgs/Image",
+  "/main_camera/camera_info": "sensor_msgs/CameraInfo",
+  "/led/state": "led_msgs/LEDStateArray"
+}
+
+service_map = {"/led/set_leds": "led_msgs/SetLEDs"}
+
+
+master = ServerProxy(os.environ['ROS_MASTER_URI'])
+remote_master = ServerProxy(os.environ['PROXY_ADDRESS'])
+
+topic_publishers = { topic: [] for topic in topics_map }
+service_providers = { service: "" for service in service_map }
+
+should_shutdown = False
+
+def map_uri_to_id(uri):
+  urlparse_result = urlparse(uri)
+  return f"{CALLER_ID}/{urlparse_result.hostname}_{urlparse_result.port}"
+
+
+
+class CurrentNodeApi(SimpleXMLRPCServer):
+
+  def __init__(self,
+               addr,
+               requestHandler=SimpleXMLRPCRequestHandler,
+               logRequests=True,
+               allow_none=False,
+               encoding=None,
+               bind_and_activate=True,
+               use_builtin_types=False):
+    SimpleXMLRPCServer.__init__(self, addr, requestHandler, logRequests, allow_none, encoding, bind_and_activate, use_builtin_types)
+
+    self.register_introspection_functions()
+
+    self.register_function(self.getBusStats)
+    self.register_function(self.getBusInfo)
+    self.register_function(self.getMasterUri)
+    self.register_function(self.shutdown)
+    self.register_function(self.getPid)
+    self.register_function(self.getSubscriptions)
+    self.register_function(self.getPublications)
+    self.register_function(self.publisherUpdate)
+
+
+  def getBusStats(self, caller_id):
+    return [1, "ok", []]
+
+  def getBusInfo(self, caller_id):
+    return [1, "ok", []]
+
+  def getMasterUri(self, caller_id):
+    return [1, "ok", os.environ['ROS_MASTER_URI']]
+
+  def shutdown(self, caller_id):
+    global should_shutdown
+    should_shutdown = True
+
+  def getPid(self, caller_id):
+    return [1, "ok", os.getpid()]
+
+  def getSubscriptions(self, caller_id):
+    return [1, "ok", [[k, v] for k, v in topics_map.items()]]
+
+  def getPublications(self, caller_id):
+    return [1, "ok", []]
+
+  def publisherUpdate(self, caller_id, topic, publishers):
+    print("Publisher updates", caller_id)
+    prev_pubs = topic_publishers[topic]
+    for p in publishers:
+      if p not in prev_pubs:
+        print(f"New topic publisher, topic: {topic}, publisher: {p}")
+        remote_master.registerPublisher(map_uri_to_id(p), topic,
+                                        topics_map[topic], p)
+
+    for p in prev_pubs:
+      if p not in publishers:
+        print(f"Topic publisher left, topic: {topic}, publisher: {p}")
+        remote_master.unregisterPublisher(map_uri_to_id(p), topic, p)
+
+    topic_publishers[topic] = publishers
+
+    return [1, "ok", 0]
+
+
+def update_services(caller_uri):
+  for service in service_map:
+    status, _, provider = master.lookupService(CALLER_ID, service)
+    print(status, _, provider)
+    if status == 1:
+      if provider != service_providers[service]:
+        print(f"New service provider, service: {service}, provider: {provider}")
+        remote_master.registerService(map_uri_to_id(caller_uri), service, provider,
+                                      caller_uri)
+        service_providers[service] = provider
+
+with CurrentNodeApi(("0.0.0.0", 0)) as server:
+  _, port = server.server_address
+  current_node_uri = f"http://{socket.gethostname()}:{port}"
+  print("Slave api started", current_node_uri)
+
+  for topic, topic_type in topics_map.items():
+    code, statusMessage, publishers = master.registerSubscriber(CALLER_ID, topic, topic_type, current_node_uri)
+    server.publisherUpdate(CALLER_ID, topic, publishers)
+
+  update_services(current_node_uri)
+
+  sel = selectors.DefaultSelector()
+  sel.register(server, selectors.EVENT_READ)
+
+  while True:
+    events = sel.select(0.5)
+    for key, mask in events:
+      key.fileobj.handle_request()
+
+    update_services(current_node_uri)

--- a/src/container.go
+++ b/src/container.go
@@ -43,6 +43,7 @@ func CreateContainer(name string, workspace *Workspace) (*Container, error) {
 	container.Overlay = &Overlay{
 		Layers: []*OverlayEntry{
 			CreateBaseFsEntry("base"),
+			CreateBaseFsEntry("cloversim"),
 		},
 		Path: path.Join(container.Path, "rootfs"),
 		Logger: container.Logger,

--- a/src/container.go
+++ b/src/container.go
@@ -194,7 +194,7 @@ func (container *Container) SendXauth() error {
 		return err
 	}
 	l := strings.Split(string(out), "\n")
-	for i, _ := range l {
+	for i := range l {
 
 		parts := strings.Fields(string(l[i]))
 		if len(parts) > 0 {

--- a/src/container.go
+++ b/src/container.go
@@ -259,6 +259,10 @@ func (container *Container) Exec(options ExecContainerOptions) *exec.Cmd {
 	return exec.Command("systemd-run", runOptions...)
 }
 
+func (container *Container) Systemctl(options ...string) error {
+	return exec.Command("systemctl", append([]string{"--machine="+container.Name}, options...)...).Run()
+}
+
 func (container *Container) Poweroff() error {
-	return exec.Command("systemctl", "--machine=" + container.Name, "poweroff").Run()
+	return container.Systemctl("poweroff")
 }

--- a/src/container.go
+++ b/src/container.go
@@ -100,6 +100,7 @@ func CreateContainer(name string, workspace *Workspace) (*Container, error) {
 	}
 
 	os.MkdirAll(container.Path, os.ModePerm)
+	os.MkdirAll(path.Join(container.Path, "shared"), os.ModePerm)
 
 	err := mountOverlayRootfs(container)
 	if err != nil {
@@ -107,7 +108,7 @@ func CreateContainer(name string, workspace *Workspace) (*Container, error) {
 		return container, err
 	}
 
-	ioutil.WriteFile(path.Join(container.Path, "hostname"), []byte(container.Name + "\n"), 0644)
+	ioutil.WriteFile(container.ContainerFile("hostname"), []byte(container.Name + "\n"), 0644)
 
 	return container, nil
 }
@@ -265,4 +266,17 @@ func (container *Container) Systemctl(options ...string) error {
 
 func (container *Container) Poweroff() error {
 	return container.Systemctl("poweroff")
+}
+
+func (container *Container) ContainerFile(name string) string {
+	return path.Join(container.Path, name)
+}
+
+var createdShared = false
+func SharedContainerFile(name string) string {
+	if !createdShared {
+		os.MkdirAll(path.Join(LocateSetup(), "containers", "_shared"), os.ModePerm)
+		createdShared = true
+	}
+	return 	path.Join(LocateSetup(), "containers", "_shared", name)
 }

--- a/src/containerPlugins.go
+++ b/src/containerPlugins.go
@@ -106,7 +106,7 @@ ExecStart="/bin/bash" "-ic" ". /etc/profile; . ~/.bashrc; mkfifo /tmp/cloversim_
 	plugin.RunOnBoot = func(container *Container) error {
 		if launch {
 			container.Logger.Info("Starting simulator")
-			return exec.Command("systemctl", "--machine="+container.Name, "start", "cloversim.service").Run()
+			return container.Systemctl("start", "cloversim.service")
 		}
 		return nil
 	}

--- a/src/containerPlugins.go
+++ b/src/containerPlugins.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path"
 	"strconv"
 	"strings"
 )
@@ -93,7 +92,7 @@ User=1000
 Group=1000
 ExecStart="/bin/bash" "-ic" ". /etc/profile; . ~/.bashrc; mkfifo /tmp/cloversim_inp; cat /tmp/cloversim_inp | roslaunch --wait cloversim %s.launch"
 `, mode)
-	servicePath := path.Join(container.Path, "cloversim.service")
+	servicePath := container.ContainerFile("cloversim.service")
 	err := ioutil.WriteFile(servicePath, []byte(service), 0644)
 	if err != nil {
 		return plugin, err

--- a/src/containerPlugins.go
+++ b/src/containerPlugins.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"strconv"
+	"strings"
+)
+
+func NewX11Plugin() (*ContainerPlugin, error) {
+
+	plugin := &ContainerPlugin{
+		Name: "X11",
+	}
+
+	if len(os.Getenv("DISPLAY")) < 2 {
+		return plugin, fmt.Errorf("x11 display not found, DISPLAY environment variable is not set")
+	}
+
+	plugin.MountsRO = []string{
+		fmt.Sprintf("/tmp/.X11-unix/X%s:/tmp/.X11-unix/X0", os.Getenv("DISPLAY")[1:]),
+		"/tmp/.virgl_test",
+	}
+
+	plugin.RunOnBoot = func(container *Container) error {
+		xauthCmd := exec.Command("xauth", "nextract", "-", os.Getenv("DISPLAY"))
+		out, err := xauthCmd.Output()
+		if err != nil {
+			return err
+		}
+		l := strings.Split(string(out), "\n")
+		for i := range l {
+
+			parts := strings.Fields(string(l[i]))
+			if len(parts) > 0 {
+				parts[0] = "ffff"
+
+				dd, err := strconv.Atoi(parts[len(parts)-5])
+				if err != nil {
+					fmt.Printf("ERROR, xauth, report this to cloversim developers: %s\n", out)
+					panic(err)
+				}
+
+				di, err := strconv.Atoi(os.Getenv("DISPLAY")[1:])
+				if err != nil {
+					fmt.Printf("ERROR, xauth, report this to cloversim developers: %s\n", out)
+					panic(err)
+				}
+
+				parts[len(parts)-5] = strconv.Itoa(dd - di)
+			}
+			l[i] = strings.Join(parts, " ")
+		}
+
+		out = []byte(strings.Join(l, "\n"))
+
+		containerCmd := container.Exec(ExecContainerOptions{
+			Command:     "xauth nmerge - ",
+			Description: "Setup xauth",
+			Uid:         1000,
+			ServiceOptions: map[string]string{
+				"After": "multi-user.target",
+				"Wants": "multi-user.target",
+			},
+		})
+		containerCmd.Stdin = bytes.NewReader(out)
+		return containerCmd.Run()
+	}
+
+	return plugin, nil
+}
+
+func NewSimulatorServicePlugin(container *Container, mode string, launch bool) (*ContainerPlugin, error) {
+
+	plugin := &ContainerPlugin{
+		Name: "cloversimService",
+	}
+
+	service := fmt.Sprintf(`
+[Unit]
+Description=Start simulator
+After=roscore.target
+Wants=roscore.target
+
+[Service]
+EnvironmentFile=/etc/environment
+RemainAfterExit=yes
+User=1000
+Group=1000
+ExecStart="/bin/bash" "-ic" ". /etc/profile; . ~/.bashrc; mkfifo /tmp/cloversim_inp; cat /tmp/cloversim_inp | roslaunch --wait cloversim %s.launch"
+`, mode)
+	servicePath := path.Join(container.Path, "cloversim.service")
+	err := ioutil.WriteFile(servicePath, []byte(service), 0644)
+	if err != nil {
+		return plugin, err
+	}
+
+	plugin.MountsRO = []string{
+		servicePath + ":/etc/systemd/system/cloversim.service",
+	}
+
+	plugin.RunOnBoot = func(container *Container) error {
+		if launch {
+			container.Logger.Info("Starting simulator")
+			return exec.Command("systemctl", "--machine="+container.Name, "start", "cloversim.service").Run()
+		}
+		return nil
+	}
+
+	return plugin, nil
+}

--- a/src/logger.go
+++ b/src/logger.go
@@ -18,6 +18,8 @@ const (
 
 var logMutex sync.Mutex
 
+var PromptString string
+
 type Logger struct {
 	Machine string
 	MachinePrefix string
@@ -73,7 +75,9 @@ func (l *Logger) Printf(prefix string, format string, v ...interface{}) {
 
 func (l *Logger) Print(prefix string, s string) {
 	logMutex.Lock()
-	fmt.Printf("[ %s ][%s]: %s\n", prefix, l.MachinePrefix, s)
+	promptClean()
+	fmt.Printf("[ %s ][%s]: %s\n\r", prefix, l.MachinePrefix, s)
+	promptShow()
 	logMutex.Unlock()
 }
 
@@ -85,10 +89,31 @@ func (l *Logger) Eprintf(prefix string, format string, v ...interface{}) {
 
 func (l *Logger) Eprint(prefix string, s string) {
 	logMutex.Lock()
-	fmt.Fprintf(os.Stderr, "[ %s ][%s]: %s\n", prefix, l.MachinePrefix, s)
+	promptClean()
+	fmt.Fprintf(os.Stderr, "[ %s ][%s]: %s\n\r", prefix, l.MachinePrefix, s)
+	promptShow()
 	logMutex.Unlock()
 }
 
+func promptClean() {
+	fmt.Print("\x1b[1000D\x1b[2K")
+}
+
+func promptShow() {
+	fmt.Print(PromptString)
+}
+
+func SetPrompt(prompt string) {
+	if prompt == PromptString {
+		return
+	}
+
+	logMutex.Lock()
+	promptClean()
+	PromptString = prompt
+	promptShow()
+	logMutex.Unlock()
+}
 
 func SetLogLevel(level LogLevel) {
 	logLevel = level

--- a/src/logger.go
+++ b/src/logger.go
@@ -8,8 +8,6 @@ import (
 	"github.com/FTL-team/clover_sim/src/color"
 )
 
-var statusStrings []string
-
 type LogLevel int
 var logLevel LogLevel
 const (

--- a/src/main.go
+++ b/src/main.go
@@ -118,6 +118,24 @@ func main() {
 							return ImportWorkspace(c.Args().First())
 						},
 					},
+
+					{
+						Name:      "duplicate",
+						Usage:     "Create copy of workspace",
+						ArgsUsage: "SOURCE_WORKSPACE DUPLICATED_WORKSPACE_NAME",
+						Action: func(c *cli.Context) error {
+							if c.Args().Len() != 2 {
+								cli.ShowCommandHelp(c, "duplicate")
+
+								return fmt.Errorf("no source workspace or duplicate workspace name not specified")
+							}
+							workspace, err := LoadWorkspace(c.Args().First())
+							if err != nil {
+								return err
+							}
+							return workspace.Duplicate(c.Args().Get(1))
+						},
+					},
 				},
 			}, {
 				Name: "prepare",

--- a/src/main.go
+++ b/src/main.go
@@ -49,7 +49,7 @@ func main() {
 						Action: func(c *cli.Context) error {
 							if c.Args().Len() != 1 {
 								cli.ShowCommandHelp(c, "create")
-								return fmt.Errorf("No name specified")
+								return fmt.Errorf("no name specified")
 							}
 							_, err := CreateWorkspace(c.Args().First())
 							return err
@@ -61,7 +61,7 @@ func main() {
 						Action: func(c *cli.Context) error {
 							if c.Args().Len() != 1 {
 								cli.ShowCommandHelp(c, "remove")
-								return fmt.Errorf("No name specified")
+								return fmt.Errorf("no name specified")
 							}
 							workspace, err := LoadWorkspace(c.Args().First())
 							
@@ -97,7 +97,7 @@ func main() {
 						Action: func(c *cli.Context) error {
 							if c.Args().Len() != 1 {
 								cli.ShowCommandHelp(c, "remove")
-								return fmt.Errorf("No name specified")
+								return fmt.Errorf("no name specified")
 							}
 							workspace, err := LoadWorkspace(c.Args().First())
 							if err != nil {
@@ -113,7 +113,7 @@ func main() {
 						Action: func(c *cli.Context) error {
 							if c.Args().Len() != 1 {
 								cli.ShowCommandHelp(c, "import")
-								return fmt.Errorf("No path to file specified")
+								return fmt.Errorf("no path to file specified")
 							}
 							return ImportWorkspace(c.Args().First())
 						},
@@ -132,7 +132,7 @@ func main() {
 				Action: func(c *cli.Context) error {
 					if c.Args().Len() != 1 {
 						cli.ShowCommandHelp(c, "remove")
-						return fmt.Errorf("No workspace name specified")
+						return fmt.Errorf("no workspace name specified")
 					}
 					workspace, err := LoadWorkspace(c.Args().First())
 					if err != nil {

--- a/src/main.go
+++ b/src/main.go
@@ -170,6 +170,19 @@ func main() {
 						NoStart: c.Bool("no-start"),
 					})
 				},
+			}, {
+				Name: "rebuild_cloversim",
+				Hidden: true,
+				HideHelp: true,
+				Flags: []cli.Flag{
+					&cli.BoolFlag{
+						Name: "fast",
+					},
+				},
+				
+				Action: func(c *cli.Context) error {
+					return BuildCloversimLayer(c.Bool("fast"))
+				},
 			},
 		},
 	}

--- a/src/main.go
+++ b/src/main.go
@@ -147,6 +147,13 @@ func main() {
 				Name: "launch",
 				Usage: "Launch simulator",
 				ArgsUsage: "WORKSPACE_NAME",
+				Flags: []cli.Flag{
+					&cli.BoolFlag{
+						Name: "no-start",
+						Usage: "disable automatic simulator(gazebo, px4, clover, etc.) start",
+					},
+				},
+				
 				Action: func(c *cli.Context) error {
 					if c.Args().Len() != 1 {
 						cli.ShowCommandHelp(c, "remove")
@@ -158,7 +165,10 @@ func main() {
 						return err
 					}
 
-					return LaunchSimulator(workspace)
+					return LaunchSimulator(SimulatorOptions{
+						Workspace: workspace,
+						NoStart: c.Bool("no-start"),
+					})
 				},
 			},
 		},

--- a/src/network.go
+++ b/src/network.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"path"
 	"strconv"
 )
 
@@ -30,7 +29,7 @@ func SetupNetwork() (*NetworkConfig, error) {
 	net := &NetworkConfig{
 		BridgeName:   "cloversim",
 		AllocatedIPs: map[int]bool{1: true},
-		HostsPath:    path.Join(LocateSetup(), "containers", "hosts"),
+		HostsPath:    SharedContainerFile("hosts"),
 	}
 
 	setupCommands := [][]string{
@@ -108,8 +107,8 @@ func (net *NetworkConfig) GetNetworkPlugin(container *Container, desiredIP int) 
 	net.AddHosts(ip, container.Name)
 
 	plugin.MountsRO = []string{
-		path.Join(LocateSetup(), "containers", "hosts") + ":/etc/hosts",
-		path.Join(container.Path, "hostname") + ":/etc/hostname",
+		SharedContainerFile("hosts") + ":/etc/hosts",
+		container.ContainerFile("hostname") + ":/etc/hostname",
 	}
 
 	plugin.LauncherArguments = []string{

--- a/src/network.go
+++ b/src/network.go
@@ -90,7 +90,7 @@ func (net *NetworkConfig) GetNextIP(desired int) string {
 		desired = 10			
 	}
 
-	for net.AllocatedIPs[desired] == true {
+	for net.AllocatedIPs[desired] {
 		desired++
 	}
 	net.AllocatedIPs[desired] = true

--- a/src/overlay.go
+++ b/src/overlay.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"os"
+	"fmt"
+	"syscall"
+	"path"
+	"path/filepath"
+	"time"
+)
+
+type OverlayEntry struct {
+	Path string
+	OverlayWork string
+	Destroy func() 
+}
+
+type Overlay struct {
+	Layers []*OverlayEntry
+	OverlayLayer *OverlayEntry
+
+	Path string
+	Logger *Logger
+}
+
+func (ov *Overlay) Mount() error {
+	lowerDir := ""
+	for i, base := range ov.Layers {
+		if i != 0 {
+			lowerDir += ":"
+		}
+		base_real, err := filepath.EvalSymlinks(base.Path)
+		if err != nil {
+			return err
+		}
+		lowerDir += base_real
+	}
+
+	upperDir := ov.OverlayLayer.Path
+	workDir := ov.OverlayLayer.OverlayWork
+	targetDir := ov.Path
+	
+	os.Mkdir(workDir, os.ModePerm)
+	os.MkdirAll(targetDir, os.ModePerm)
+
+	options := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lowerDir, upperDir, workDir)
+
+	ov.Logger.Verbose("Mounting overlay rootfs: mount -t overlay overlay %s %s", targetDir, options)
+
+	return syscall.Mount("overlay", targetDir, "overlay", 0, options)
+}
+
+func (ov *Overlay) Destroy() {
+	for i := 0; i < 3; i++ {
+		syscall.Unmount(ov.Path, 0)
+		time.Sleep(time.Second / 2)
+	}
+	os.Remove(ov.OverlayLayer.OverlayWork)
+
+	for _, entry := range ov.Layers {
+		if entry.Destroy != nil {
+			entry.Destroy()
+		}
+	}
+	if ov.OverlayLayer.Destroy != nil {
+		ov.OverlayLayer.Destroy()
+	}
+}
+
+func CreateTmpFsEntry(targetDir string) (*OverlayEntry, error) {
+	entry := &OverlayEntry{
+		Path: path.Join(targetDir, "fs"),
+		OverlayWork: path.Join(targetDir, ".overlay_work"),
+		Destroy: func() {
+			for i := 0; i < 3; i++ {
+				syscall.Unmount(targetDir, 0)
+				time.Sleep(time.Second / 3)
+			}
+		},
+	}
+
+	os.MkdirAll(targetDir, os.ModePerm)
+	err := syscall.Mount("tmpfs", targetDir, "tmpfs", 0, "")
+	if err != nil {
+		return entry, err
+	}
+	
+	err = os.MkdirAll(path.Join(targetDir, "fs"), os.ModePerm)
+	return entry, err
+}
+
+func CreateBaseFsEntry(name string) (*OverlayEntry) {
+	entry := &OverlayEntry{
+		Path: path.Join(LocateSetup(), "base_fs", name),
+		OverlayWork: path.Join(LocateSetup(), "base_fs", ".overlay_work_" + name),
+	}
+	return entry
+}

--- a/src/overlay.go
+++ b/src/overlay.go
@@ -40,6 +40,7 @@ func (ov *Overlay) Mount() error {
 	workDir := ov.OverlayLayer.OverlayWork
 	targetDir := ov.Path
 	
+	os.RemoveAll(workDir)
 	os.Mkdir(workDir, os.ModePerm)
 	os.MkdirAll(targetDir, os.ModePerm)
 

--- a/src/prepare.go
+++ b/src/prepare.go
@@ -39,3 +39,38 @@ func Prepare() error {
 
 	return nil
 }
+
+func BuildCloversimLayer() error {
+	HostLogger.Info("Building cloversim layer, this may take a while...")
+
+	layerPath := path.Join(LocateSetup(), "base_fs", "cloversim")
+	buildContainerPath := path.Join(LocateSetup(), "containers", "__build_cloversim")
+	os.RemoveAll(layerPath)
+	os.MkdirAll(layerPath, os.ModePerm)
+
+	overlay := &Overlay{
+		Layers: []*OverlayEntry{
+			CreateBaseFsEntry("base"),
+		},
+
+		OverlayLayer: CreateBaseFsEntry("cloversim"),
+		
+		Path: buildContainerPath,
+		Logger: HostLogger,
+	}
+	defer overlay.Destroy()
+
+	if err:= overlay.Mount(); err != nil {
+		return err
+	}
+
+	binder := path.Join(LocateSetup(), "sim") + ":/sim"
+
+	cmd := exec.Command("systemd-nspawn", "-u", "clover", "--bind-ro", binder, "-D", overlay.Path, "/bin/bash", "-i", "/sim/build.sh")
+
+	err := cmd.Run()
+	if err != nil {
+		HostLogger.Error("Build failed, %s", err)
+	}
+	return err
+}

--- a/src/prepare.go
+++ b/src/prepare.go
@@ -42,12 +42,14 @@ func Prepare() error {
 	return nil
 }
 
-func BuildCloversimLayer() error {
+func BuildCloversimLayer(buildFast bool) error {
 	HostLogger.Info("Building cloversim layer, this may take a while...")
 
 	layerPath := path.Join(LocateSetup(), "base_fs", "cloversim")
 	buildContainerPath := path.Join(LocateSetup(), "containers", "__build_cloversim")
-	os.RemoveAll(layerPath)
+	if !buildFast {
+		os.RemoveAll(layerPath)
+	}
 	os.MkdirAll(layerPath, os.ModePerm)
 
 	overlay := &Overlay{

--- a/src/simulator.go
+++ b/src/simulator.go
@@ -97,9 +97,11 @@ func LaunchMachine(options MachineOptions, sim *Simulator) error {
 }
 
 func LaunchSimulator(options SimulatorOptions) error {
-	if err := BuildCloversimLayer(); err != nil {
-		HostLogger.Error("Failed to build cloversim layer: %s", err)
-		return err
+	if ShouldRebuildCloversimLayer() {
+		if err := BuildCloversimLayer(); err != nil {
+			HostLogger.Error("Failed to build cloversim layer: %s", err)
+			return err
+		}
 	}
 	
 	go StartVirgl()

--- a/src/simulator.go
+++ b/src/simulator.go
@@ -98,7 +98,7 @@ func LaunchMachine(options MachineOptions, sim *Simulator) error {
 
 func LaunchSimulator(options SimulatorOptions) error {
 	if ShouldRebuildCloversimLayer() {
-		if err := BuildCloversimLayer(); err != nil {
+		if err := BuildCloversimLayer(false); err != nil {
 			HostLogger.Error("Failed to build cloversim layer: %s", err)
 			return err
 		}

--- a/src/simulator.go
+++ b/src/simulator.go
@@ -97,6 +97,11 @@ func LaunchMachine(options MachineOptions, sim *Simulator) error {
 }
 
 func LaunchSimulator(options SimulatorOptions) error {
+	if err := BuildCloversimLayer(); err != nil {
+		HostLogger.Error("Failed to build cloversim layer: %s", err)
+		return err
+	}
+	
 	go StartVirgl()
 	time.Sleep(time.Second)
 

--- a/src/simulator.go
+++ b/src/simulator.go
@@ -168,6 +168,7 @@ func LaunchSimulator(options SimulatorOptions) error {
 	go SimulatorController(c, promptExit, simulatorCommands)
 
 	wg.Wait()
+	promptExit <- true
 	HostLogger.Info("All containers stopped")
 
 	return nil

--- a/src/simulatorControl.go
+++ b/src/simulatorControl.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"golang.org/x/term"
+)
+
+func ProcessCommand(command string, interruptChanel chan os.Signal, simulatorCommands chan SimulatorCommand) {
+  if len(command) == 0 {
+    return
+  } 
+
+  parts := strings.Split(command, " ")
+  if len(parts) == 0 {
+    return
+  }
+
+  switch parts[0] {
+  case "help":
+    fmt.Println("\r")
+    fmt.Println("\rAvailable commands:")
+    fmt.Println("\r  help               - show this help")
+    fmt.Println("\r  exit               - shutdowns cloversim")
+    fmt.Println("\r  simulator start    - start simulator (gazebo, clover, etc.)")
+    fmt.Println("\r  simulator stop     - stop simulator (gazebo, clover, etc.)")
+    fmt.Println("\r  simulator restart  - restart the simulator (gazebo, clover, etc.)")
+  case "exit":
+    interruptChanel <- os.Interrupt
+  case "simulator":
+    if len(parts) < 2 {
+      HostLogger.Error("Not enough arguments for simulator command, check help")
+    }
+    switch parts[1] {
+    case "start":
+      simulatorCommands <- SimulatorCommand{
+        Command: "machine",
+        MachineCommand: MachineCommand{
+          Command: "simulator_start",
+        },
+      }
+
+    case "stop":
+      simulatorCommands <- SimulatorCommand{
+        Command: "machine",
+        MachineCommand: MachineCommand{
+          Command: "simulator_stop",
+        },
+      }
+
+    case "restart":
+      simulatorCommands <- SimulatorCommand{
+        Command: "machine",
+        MachineCommand: MachineCommand{
+          Command: "simulator_stop",
+        },
+      }
+
+      time.Sleep(time.Second)
+
+      simulatorCommands <- SimulatorCommand{
+        Command: "machine",
+        MachineCommand: MachineCommand{
+          Command: "simulator_start",
+        },
+      }
+    
+    default:
+      HostLogger.Error("Unknown command: %s, check help", parts[0])
+      
+    }
+  default:
+    HostLogger.Error("Unknown command: %s, check help", parts[0])
+  }
+
+}
+
+func SimulatorController(interruptChanel chan os.Signal, exitChan chan bool,  simulatorCommands chan SimulatorCommand) {
+	if IsTTY() {
+
+		oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
+		if err != nil {
+			fmt.Println(err)
+			return
+		}
+		defer func() {
+      term.Restore(int(os.Stdin.Fd()), oldState)
+    }()
+	}
+
+	inp := make(chan byte)
+  hist := []string{}
+  
+	go func() {
+		b := make([]byte, 1)
+		for {
+			_, err := os.Stdin.Read(b)
+			if err != nil {
+				HostLogger.Error("%s", err)
+				return
+			}
+			inp <- b[0]
+		}
+	}()
+  
+  input := ""
+  pos := 0
+  
+  hist_save := ""
+  hist_pos := 0
+
+  mode := 0
+  SetPrompt(">>> ")
+
+mainLoop:
+	for {
+		select {
+		case <-exitChan:
+			break mainLoop
+
+		case ch := <-inp:
+      if mode == 0 {
+        if ch >= 32 && ch <= 126 {
+          input = input[:pos] + string(ch) + input[pos:]
+          pos++
+        } else if ch == 10 || ch == 13 {
+          fmt.Println("\r>>> " + input)
+          SetPrompt("")
+          if len(hist) == 0 || hist[len(hist)-1] != input {
+            hist = append(hist, input)
+          }
+
+          ProcessCommand(input, interruptChanel,  simulatorCommands)
+          pos = 0
+          input = ""
+          hist_pos = 0
+          hist_save = ""
+        } else if ch == 3 || ch == 4 {
+          interruptChanel <- os.Interrupt
+        } else if ch == 27 {
+          mode = 1
+        } else if ch == 127 {
+          if pos > 0 {
+            input = input[:pos-1] + input[pos:]
+            pos--
+          }
+        }
+      } else if mode == 1 {
+        if ch == 91 {
+          mode = 2
+        } else {
+          mode = 0
+        }
+      } else if mode == 2 {
+        
+        if ch == 68 {
+          if pos > 0 {
+            pos--
+          }
+        }else if ch == 67 {
+          if pos < len(input) {
+            pos ++
+          }
+        }else if ch == 66 {
+          if hist_pos > 0 {
+            hist_pos--
+          }
+          if hist_pos == 0 {
+            input = hist_save
+          }else{
+            input = hist[len(hist)-hist_pos]
+          }
+          pos = len(input)
+        } else if ch == 65 {
+          if hist_pos == 0 {
+            hist_save = input
+          }
+
+          if hist_pos < len(hist) {
+            hist_pos++
+          }
+          if hist_pos == 0 {
+            input = hist_save
+          }else{
+            input = hist[len(hist)-hist_pos]
+          }
+          pos = len(input)
+        }
+
+        mode = 0
+      }
+
+      prompt := ">>> " + input + "\x1b[1000D"
+      prompt += fmt.Sprintf("\x1b[%dC", pos + 4)
+      SetPrompt(prompt)
+		}
+	}
+  SetPrompt("")
+
+}

--- a/src/utils.go
+++ b/src/utils.go
@@ -46,7 +46,7 @@ func ExecCommands(commands [][]string) (error) {
 	for _, cmd := range commands {
 		out, err := exec.Command(cmd[0], cmd[1:]...).CombinedOutput()
 		if err != nil {
-			return fmt.Errorf("Failed to run command:\nOutput: \n%s\nError: %s", out, err)
+			return fmt.Errorf("failed to run command:\nOutput: \n%s\nError: %s", out, err)
 		}
 	}
 	return nil

--- a/src/utils.go
+++ b/src/utils.go
@@ -51,3 +51,8 @@ func ExecCommands(commands [][]string) (error) {
 	}
 	return nil
 }
+
+func IsTTY() bool {
+    fileInfo, _ := os.Stdout.Stat() 
+		return (fileInfo.Mode() & os.ModeCharDevice) != 0
+}

--- a/src/virgl.go
+++ b/src/virgl.go
@@ -31,7 +31,3 @@ func StartVirgl() {
 		panic(err)
 	}
 }
-
-func setup_virgl() {
-
-}

--- a/src/workspace.go
+++ b/src/workspace.go
@@ -223,3 +223,11 @@ func (sourceWorkspace *Workspace) Duplicate(targetName string) error {
 
 	return targetWorkspace.Save()
 }
+
+func (workspace *Workspace) CreateOverlayEntry() (*OverlayEntry) {
+	overlayEntry := &OverlayEntry{
+		Path: path.Join(workspace.Path, "fs"),
+		OverlayWork: path.Join(workspace.Path, ".overlay_work"),
+	}
+	return overlayEntry
+}

--- a/src/workspace.go
+++ b/src/workspace.go
@@ -21,6 +21,22 @@ type WorkspaceSerialized struct {
 	Name string `yaml:"name"`
 }
 
+func validateWorkspaceName(name string) error {
+	for _, c := range name {
+
+		ok := false
+		ok = ok || (c > 'a' && c < 'z')
+		ok = ok || (c > 'A' && c < 'Z')
+		ok = ok || (c > '0' && c < '9')
+		ok = ok || (c == '_')
+		if !ok {
+			return fmt.Errorf("invalid workspace name: %s, namespace names can contain only latin letters, numbers, and underscores", name)
+		}
+	}
+
+	return nil
+}
+
 func (workspace *Workspace) Serialize() ([]byte, error) {
 	return yaml.Marshal(&WorkspaceSerialized{
 		Name: workspace.Name,
@@ -34,6 +50,10 @@ func DeserializeWorkspace(data []byte) (*Workspace, error) {
 		return nil, err
 	}
 
+	if err := validateWorkspaceName(workspaceSerialized.Name); err != nil {
+		return nil, err
+	}
+
 	return &Workspace{
 		Name: workspaceSerialized.Name,
 	}, nil
@@ -41,6 +61,11 @@ func DeserializeWorkspace(data []byte) (*Workspace, error) {
 
 
 func CreateWorkspace(name string) (*Workspace, error) {
+
+	if err := validateWorkspaceName(name); err != nil {
+		return nil, err
+	}
+
 	Workspace := &Workspace{
 		Name: name,
 		Path: path.Join(LocateSetup(), "workspaces", name),


### PR DESCRIPTION
## UI
- Add workspace name validation, workspace should contain only latine letters, numbers and underscores
- Add command for duplicating workspaces, suggestedd by @mkulik05 
- Implement in-command cli that allows to stop, start and restart simulator(gazebo, clover, etc...), poweroff simulator, and can display help

## Refactoring
- Fix linter warnings
- Refactor container system, instead of editing getlaunhcer from now we should implement container plugin, which can add mounts, add launcher arguments and run custom functions after container launch, current plugins are: `X11Plugin`, `SimulatorServicePlugin`, `NetworkPlugin`
- Implement new functions that simplifies getting path of shared and local files
- Separate working with overlayfs into `overlay.go` and `Overlay` struct 
- Add vscode config so it won't monitor changes in container and base fs

## System
- Files shared between containers are now located at containers/_shared
- Moved the simulator-part(ros, gazebo, etc...) code from base_fs to tool code. Simulator-part will be located in cloversim overlayfs layer, and it will be rebuilt in case of versions inside layer and tool are different
